### PR TITLE
Add type check at unmarshal JSON calls

### DIFF
--- a/featurecollection.go
+++ b/featurecollection.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // TypeFeatureCollection is the value for a FeatureCollection's 'type' member.
 const TypeFeatureCollection string = "FeatureCollection"
@@ -27,12 +30,17 @@ func (f FeatureCollection) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON is a custom JSON unmarshaller.
 func (f *FeatureCollection) UnmarshalJSON(b []byte) error {
 	var tmp struct {
+		Type     string     `json:"type"`
 		Features []Feature  `json:"features"`
 		Bbox     []Position `json:"bbox"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != TypeFeatureCollection {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, TypeFeatureCollection)
 	}
 
 	f.Features = tmp.Features

--- a/geometrycollection.go
+++ b/geometrycollection.go
@@ -2,6 +2,7 @@ package joejson
 
 import (
 	"encoding/json"
+	"fmt"
 )
 
 // GeometryTypeGeometryCollection is the value for a GeometryCollection's 'type' member.
@@ -55,10 +56,15 @@ func (g GeometryCollection) MarshalJSON() ([]byte, error) {
 func (g *GeometryCollection) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Geometries []json.RawMessage `json:"geometries"`
+		Type       string            `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypeGeometryCollection {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypeGeometryCollection)
 	}
 
 	for _, geom := range tmp.Geometries {

--- a/linestring.go
+++ b/linestring.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypeLineString is the value for a LineString's 'type' member.
 const GeometryTypeLineString = "LineString"
@@ -32,10 +35,15 @@ func (g LineString) MarshalJSON() ([]byte, error) {
 func (g *LineString) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Positions []Position `json:"coordinates"`
+		Type      string     `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypeLineString {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypeLineString)
 	}
 
 	*g = LineString(tmp.Positions)

--- a/multilinestring.go
+++ b/multilinestring.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypeMultiLineString is the value for a MultiLineString's 'type' member.
 const GeometryTypeMultiLineString = "MultiLineString"
@@ -36,10 +39,15 @@ func (g MultiLineString) MarshalJSON() ([]byte, error) {
 func (g *MultiLineString) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		LineStrings [][]Position `json:"coordinates"`
+		Type        string       `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypeMultiLineString {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypeMultiLineString)
 	}
 
 	*g = make([]LineString, len(tmp.LineStrings))

--- a/multipoint.go
+++ b/multipoint.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypeMultiPoint is the value for a MultiPoint's 'type' member.
 const GeometryTypeMultiPoint = "MultiPoint"
@@ -32,10 +35,15 @@ func (g MultiPoint) MarshalJSON() ([]byte, error) {
 func (g *MultiPoint) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Positions []Position `json:"coordinates"`
+		Type      string     `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypeMultiPoint {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypeMultiPoint)
 	}
 
 	*g = MultiPoint(tmp.Positions)

--- a/multipolygon.go
+++ b/multipolygon.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypeMultiPolygon is the value for a MultiPolygon's 'type' member.
 const GeometryTypeMultiPolygon = "MultiPolygon"
@@ -36,10 +39,15 @@ func (p MultiPolygon) MarshalJSON() ([]byte, error) {
 func (p *MultiPolygon) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Polygons [][]LinearRing `json:"coordinates"`
+		Type     string         `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypeMultiPolygon {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypeMultiPolygon)
 	}
 
 	*p = make(MultiPolygon, len(tmp.Polygons))

--- a/point.go
+++ b/point.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypePoint is the value for a Point's 'type' member.
 const GeometryTypePoint = "Point"
@@ -28,10 +31,15 @@ func (p Point) MarshalJSON() ([]byte, error) {
 func (p *Point) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Position Position `json:"coordinates"`
+		Type     string   `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypePoint {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypePoint)
 	}
 
 	*p = Point(tmp.Position)

--- a/polygon.go
+++ b/polygon.go
@@ -1,6 +1,9 @@
 package joejson
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // GeometryTypePolygon is the value for a Polygon's 'type' member.
 const GeometryTypePolygon = "Polygon"
@@ -44,10 +47,15 @@ func (p Polygon) MarshalJSON() ([]byte, error) {
 func (p *Polygon) UnmarshalJSON(b []byte) error {
 	var tmp struct {
 		Rings []LinearRing `json:"coordinates"`
+		Type  string       `json:"type"`
 	}
 
 	if err := json.Unmarshal(b, &tmp); err != nil {
 		return err
+	}
+
+	if tmp.Type != GeometryTypePolygon {
+		return fmt.Errorf("invalid type %q, expected %q", tmp.Type, GeometryTypePolygon)
 	}
 
 	*p = tmp.Rings


### PR DESCRIPTION
I've added type checks so when unmarshalling a JSON we throw an error if the type doesn't match the expected one.
I have to say that I am concerned about the performance implications that it might have to add this kind of checks for performance critical applications.

Also, I've also added those checks for geometry types, but it is quite redundant since if the geometry is unmarshalled from [unmarshalGeometry](https://github.com/GerardRodes/joejson/blob/ecb2535c457f7d3e2104209b8b8c4f59d6e2fe45/feature.go#L169) will never have wrong type, should we assume that it is always being to be called from there and skip the type check?
If that's the case maybe we should think about exporting `unmarshalGeometry`